### PR TITLE
Add context to swhid

### DIFF
--- a/invenio_swh/alembic/f3542dda222d_increase_identifier_string_length.py
+++ b/invenio_swh/alembic/f3542dda222d_increase_identifier_string_length.py
@@ -1,6 +1,6 @@
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2024 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_swh/alembic/f3542dda222d_increase_identifier_string_length.py
+++ b/invenio_swh/alembic/f3542dda222d_increase_identifier_string_length.py
@@ -1,0 +1,39 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Increase identifier string length."""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f3542dda222d"
+down_revision = "ed8813bfcb2b"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.alter_column(
+        "swh_deposit",
+        "swhid",
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=1024),
+        existing_nullable=True,
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.alter_column(
+        "swh_deposit",
+        "swhid",
+        existing_type=sa.String(length=1024),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+    )

--- a/invenio_swh/api.py
+++ b/invenio_swh/api.py
@@ -17,7 +17,8 @@ class SWHDeposit:
     This class provides an abstraction layer for interacting with Software Heritage deposits.
     It encapsulates the functionality for creating, retrieving, and managing deposits.
 
-    Attributes:
+    Attributes
+    ----------
         model_cls (class): The model class associated with the deposit.
         model (object): The instance of the model associated with the deposit.
 
@@ -26,7 +27,7 @@ class SWHDeposit:
     model_cls = SWHDepositModel
 
     def __init__(self, model=None):
-        """Constructor."""
+        """Instantiate deposit object."""
         self.model = model
 
     @classmethod

--- a/invenio_swh/client.py
+++ b/invenio_swh/client.py
@@ -94,7 +94,7 @@ class SWHCLient(object):
         """
         headers = {}
         headers["Content-Type"] = str(file_metadata.get("mimetype"))
-        headers["Content-MD5"] = str(file_metadata.get("checksum").strip("md5:"))
+        headers["Content-MD5"] = str(file_metadata.get("checksum").removeprefix("md5:"))
         headers["Content-Length"] = str(file_metadata.get("size"))
         fname = file_metadata.get("filename")
         headers["Content-Disposition"] = f"attachment; filename={fname}"

--- a/invenio_swh/client.py
+++ b/invenio_swh/client.py
@@ -22,26 +22,28 @@ class SWHCLient(object):
     serializer = SoftwareHeritageXMLSerializer
 
     def __init__(self, client, collection_iri, serializer_cls=None):
-        """Initializes the SWH client."""
+        """Initialize the SWH client."""
         self.client = client
         self.serializer = serializer_cls() if serializer_cls else self.serializer()
         self._collection_iri = collection_iri
 
     @property
     def collection_iri(self):
-        """Returns the collection IRI."""
+        """Return the collection IRI."""
         return self._collection_iri
 
     def _cleanup_data(self, data: dict, tags: list):
-        """
-        Cleans up the data dictionary by replacing specified tags.
+        """Clean up the data dictionary by replacing specified tags.
 
         Args:
+        ----
             data (dict): The data dictionary to be cleaned up.
             tags (tuple): A list of tuples tuple of (find, replace) pairs specifying the tags to be replaced.
 
         Returns:
+        -------
             dict: The cleaned up data dictionary.
+
         """
         stringified = json.dumps(data)
         for t in tags:
@@ -51,22 +53,22 @@ class SWHCLient(object):
         return json.loads(stringified)
 
     def edit_media_iri(self, deposit_id):
-        """Returns the Edit IRI of a deposit, used for file uploads."""
+        """Return the Edit IRI of a deposit, used for file uploads."""
         suffix = "media"
         return urllib.parse.urljoin(self.collection_iri, f"{deposit_id}/{suffix}/")
 
     def se_iri(self, deposit_id):
-        """Returns the Edit IRI of a deposit, used for metadata updates."""
+        """Return the Edit IRI of a deposit, used for metadata updates."""
         suffix = "metadata"
         return urllib.parse.urljoin(self.collection_iri, f"{deposit_id}/{suffix}/")
 
     def status_iri(self, deposit_id):
-        """Returns the status IRI of a deposit."""
+        """Return the status IRI of a deposit."""
         suffix = "status"
         return urllib.parse.urljoin(self.collection_iri, f"{deposit_id}/{suffix}/")
 
     def create_deposit(self, codemeta_json: dict):
-        """Creates a deposit in SWH.
+        """Create a deposit in SWH.
 
         The codemeta metadata is transformed to XML and then sent to SWH.
         """
@@ -88,7 +90,7 @@ class SWHCLient(object):
         return self._parse_response(content)
 
     def update_deposit_files(self, deposit_id, file, file_metadata: dict) -> None:
-        """Updates the files of a deposit in SWH.
+        """Update the files of a deposit in SWH.
 
         File must be a readable buffer.
         """
@@ -129,12 +131,12 @@ class SWHCLient(object):
         return self._parse_response(content)
 
     def get_deposit_status(self, deposit_id: int) -> dict:
-        """Returns the status of a deposit."""
+        """Return the status of a deposit."""
         resp, content = self.client.h.request(self.status_iri(deposit_id), "GET")
         return self._parse_response(content)
 
     def _parse_response(self, response_obj: bytes) -> dict:
-        """Parses the response from SWH and returns a dict."""
+        """Parse the response from SWH and returns a dict."""
         if not response_obj or response_obj == b"":
             return {}
         response_str = response_obj.decode("utf-8")

--- a/invenio_swh/controller/controller.py
+++ b/invenio_swh/controller/controller.py
@@ -14,7 +14,7 @@ class SWHController:
     """Software Heritage controller."""
 
     def __init__(self, client: SWHCLient) -> None:
-        """Constructor."""
+        """Insantiate controller object."""
         self.client = client
 
     def _parse_response(self, data: dict) -> dict:

--- a/invenio_swh/controller/controller.py
+++ b/invenio_swh/controller/controller.py
@@ -27,7 +27,7 @@ class SWHController:
         res = {
             "deposit_id": dpid,
             "deposit_status": data.get("deposit_status"),
-            "deposit_swhid": data.get("deposit_swh_id"),
+            "deposit_swhid": data.get("deposit_swh_id_context"),
             "response": data,
         }
         return res

--- a/invenio_swh/models.py
+++ b/invenio_swh/models.py
@@ -49,7 +49,7 @@ class SWHDepositModel(db.Model, Timestamp):
     object_uuid = db.Column(UUIDType, primary_key=True)
     """Object ID - e.g. a record id."""
 
-    swhid = db.Column(db.String(255), nullable=True)
+    swhid = db.Column(db.String(1024), nullable=True)
     """Software Hash ID."""
 
     swh_deposit_id = db.Column(db.String, nullable=True)

--- a/invenio_swh/models.py
+++ b/invenio_swh/models.py
@@ -64,5 +64,5 @@ class SWHDepositModel(db.Model, Timestamp):
     """Deposit status. It is indexed to improve the search of deposits that e.g failed."""
 
     def __repr__(self):
-        """String representation of a SWHDeposit."""
+        """Return string representation of a SWHDeposit."""
         return f"<SWHDepositModel(deposit_id={self.swh_deposit_id}, object_uuid={self.object_uuid}, status={self.status})>"

--- a/invenio_swh/schema.py
+++ b/invenio_swh/schema.py
@@ -5,13 +5,16 @@
 # Invenio-RDM is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 """Invenio-SWH service schema."""
-
+from flask import current_app
 from invenio_rdm_records.contrib.codemeta.processors import CodemetaDumper
 from invenio_rdm_records.resources.serializers.codemeta import CodemetaSchema
+from marshmallow import fields
 
 
 class SWHCodemetaSchema(CodemetaSchema):
     """Subset of Codemeta schema for Software Heritage."""
+
+    deposit = fields.Method("add_deposit_info", data_key="swh:deposit")
 
     def __init__(self, *args, **kwargs):
         """Constructor.
@@ -25,6 +28,7 @@ class SWHCodemetaSchema(CodemetaSchema):
         """Meta class, defines subset of fields to be dumped."""
 
         fields = (
+            "identifier",
             "name",
             "author",
             "datePublished",
@@ -34,4 +38,28 @@ class SWHCodemetaSchema(CodemetaSchema):
             "codeRepository",
             "programmingLanguage",
             "developmentStatus",
+            "deposit",
         )
+
+    def add_deposit_info(self, obj):
+        """Add deposit information to the codemeta."""
+        if hasattr(obj, "parent"):
+            parent_record = obj.parent
+        else:
+            parent_record = obj["parent"]
+
+        parent_doi = parent_record.get("pids", {}).get("doi")["identifier"]
+        prefix = current_app.config["DATACITE_PREFIX"]
+        doi_format = current_app.config["DATACITE_FORMAT"]
+        parent_doi = doi_format.format(prefix=prefix, id=parent_doi)
+        origin_obj = {"swh:origin": {"@url": f"https://doi.org/{parent_doi}"}}
+
+        # If the record is the first version, it dumps `create_origin`
+        # Otherwise, dumps `add_to_origin`
+        is_first_version = obj.versions.index == 1
+        ret = {}
+        if is_first_version:
+            ret["swh:create_origin"] = origin_obj
+        else:
+            ret["swh:add_to_origin"] = origin_obj
+        return ret

--- a/invenio_swh/schema.py
+++ b/invenio_swh/schema.py
@@ -49,9 +49,6 @@ class SWHCodemetaSchema(CodemetaSchema):
             parent_record = obj["parent"]
 
         parent_doi = parent_record.get("pids", {}).get("doi")["identifier"]
-        prefix = current_app.config["DATACITE_PREFIX"]
-        doi_format = current_app.config["DATACITE_FORMAT"]
-        parent_doi = doi_format.format(prefix=prefix, id=parent_doi)
         origin_obj = {"swh:origin": {"@url": f"https://doi.org/{parent_doi}"}}
 
         # If the record is the first version, it dumps `create_origin`

--- a/invenio_swh/schema.py
+++ b/invenio_swh/schema.py
@@ -17,7 +17,7 @@ class SWHCodemetaSchema(CodemetaSchema):
     deposit = fields.Method("add_deposit_info", data_key="swh:deposit")
 
     def __init__(self, *args, **kwargs):
-        """Constructor.
+        """Instantiate Codemeta schema adapted to Software Heritage.
 
         Injects the codemeta dumper into the schema processors.
         """

--- a/invenio_swh/serializer.py
+++ b/invenio_swh/serializer.py
@@ -133,6 +133,7 @@ class SoftwareHeritageXMLSerializer(MarshmallowSerializer):
     default_namespaces = {
         "default": "https://doi.org/10.5063/SCHEMA/CODEMETA-2.0",
         "atom": "http://www.w3.org/2005/Atom",
+        "swh": "https://www.softwareheritage.org/schema/2018/deposit"
     }
 
     def __init__(self, namespaces=None, **kwargs):

--- a/invenio_swh/serializer.py
+++ b/invenio_swh/serializer.py
@@ -17,27 +17,27 @@ class BaseFormatter:
     """Base formatter interface."""
 
     def to_bytes(self, obj):
-        """Converts the object to bytes."""
+        """Convert the object to bytes."""
         raise NotImplementedError
 
     def to_bytes_list(self, obj):
-        """Converts the object list to bytes."""
+        """Convert the object list to bytes."""
         raise NotImplementedError
 
     def to_str(self, obj):
-        """Converts the object to string."""
+        """Convert the object to string."""
         raise NotImplementedError
 
     def to_str_list(self, obj):
-        """Converts the object list to string."""
+        """Convert the object list to string."""
         raise NotImplementedError
 
     def to_etree(self, obj):
-        """Converts the object to etree."""
+        """Convert the object to etree."""
         raise NotImplementedError
 
     def to_etree_list(self, obj):
-        """Converts the object list to etree."""
+        """Convert the object list to etree."""
         raise NotImplementedError
 
 
@@ -73,8 +73,7 @@ class XMLFormatter(BaseFormatter):
         return self.to_bytes(self.to_etree(obj))
 
     def to_etree(self, obj):
-        """
-        Convert an object to an ElementTree object.
+        """Convert an object to an ElementTree object.
 
         :param obj: The object to be converted.
         :type obj: dict or str
@@ -103,8 +102,7 @@ class XMLFormatter(BaseFormatter):
         return _etree
 
     def to_bytes(self, obj, encoding="utf-8") -> bytes:
-        """
-        Convert an ElementTree object to bytes string.
+        """Convert an ElementTree object to bytes string.
 
         :param obj: The ElementTree object to be converted.
         :type obj: ElementTree
@@ -116,8 +114,7 @@ class XMLFormatter(BaseFormatter):
         return etree.tostring(obj, xml_declaration=True, encoding=encoding)
 
     def to_str(self, obj) -> str:
-        """
-        Convert an ElementTree object to a unicode string.
+        """Convert an ElementTree object to a unicode string.
 
         :param obj: The ElementTree object to be converted.
         :type obj: ElementTree
@@ -137,7 +134,7 @@ class SoftwareHeritageXMLSerializer(MarshmallowSerializer):
     }
 
     def __init__(self, namespaces=None, **kwargs):
-        """Constructor."""
+        """Instantiate serializer object."""
         self.namespaces = namespaces or self.default_namespaces
         super().__init__(
             format_serializer_cls=XMLFormatter,

--- a/invenio_swh/service.py
+++ b/invenio_swh/service.py
@@ -22,7 +22,7 @@ class SWHDepositResult(object):
     """Single SWHDeposit result."""
 
     def __init__(self, deposit: SWHDeposit) -> None:
-        """Constructor."""
+        """Instantiate result item."""
         self.deposit = deposit
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     invenio-access>=2.0.0
     invenio-db>=1.1.5
     invenio-records-resources>=5.0.0
+    marshmallow-utils>=0.8.1
 
 [options.extras_require]
 tests =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ RunningApp = namedtuple(
 
 @pytest.fixture
 def running_app(app, location, cache, resource_type_v):
-    """This fixture provides an app with the typically needed db data loaded.
+    """Provide an app with the typically needed db data loaded.
 
     All of these fixtures are often needed together, so collecting them
     under a semantic umbrella makes sense.
@@ -138,7 +138,7 @@ def add_file_to_draft(identity, draft_id, file_name, file_contents):
 
 @pytest.fixture(scope="function")
 def create_record_factory(identity_simple, location):
-    """Factory to create and publish a record with minimal data with, or without, files."""
+    """Return a factory to create and publish a record with minimal data with, or without, files."""
 
     def _inner(metadata, files=[]):
         s = current_rdm_records_service
@@ -153,7 +153,7 @@ def create_record_factory(identity_simple, location):
 
 @pytest.fixture(scope="function")
 def identity_simple(user):
-    """Simple identity fixture."""
+    """Return simple identity fixture."""
     i = Identity(1)
     i.provides.add(UserNeed(1))
     i.provides.add(Need(method="system_role", value="authenticated_user"))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,3 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN
+#
+# invenio-swh is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""Metadata tests for Invenio-SWH."""
+
 # import pytest
 # import xmldiff.main
 # from lxml import etree

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -8,8 +8,10 @@
 
 
 def test_publish(app):
+    """Test publish."""
     assert True
 
 
 def test_polling_status(app):
+    """Test polling mechanism for status."""
     assert True


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-swh/issues/33

* The swhid we store is now the identifier with context (e.g. origin URL)
* Added `create_origin` for new depositions
* Added `add_to_origin` for new versions of records